### PR TITLE
feat: add website search + server.js example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 test.js
 test_print.js
+node_modules
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ const main = async () => {
   console.log('Search');
   const search = await news.search('SpaceX', {n : 5});
   search.forEach(print);
+
+  console.log('Website');
+  const website = await news.website('https://www.starlink.com/', {n : 5});
+  website.forEach(print);
 };
 
 main();
@@ -120,7 +124,7 @@ Default configuration: `{ country: 'us', language: 'en', n: 10 }`.
 
 Find top 5 headlines in Great Britain written in english 
 
-```
+```javascript
 news.headlines({country: 'gb', language: 'en', n: 5})
 ```
 
@@ -130,7 +134,7 @@ Find top 5 business articles in US.
 Possible topics: `WORLD`, `BUSINESS`, `TECHNOLOGY`, `SCIENCE`,
 `ENTERTAINMENT`, `SPORTS`, `HEALTH`
 
-```
+```javascript
 news.topic('BUSINESS')
 ```
 
@@ -138,7 +142,7 @@ news.topic('BUSINESS')
 
 Find top 20 news articles about New York.
 
-```
+```javascript
 news.geo('New York', {n: 20})
 ```
 
@@ -146,9 +150,19 @@ news.geo('New York', {n: 20})
 
 Search for top news about Elon Musk's Starlink.
 
-```
+```javascript
 news.search('Starlink')
 ```
+
+#### Website
+
+Search for an specific website with ordering
+
+```javascript
+news.website('https://www.starlink.com/')
+```
+
+
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const search = async (query, {country = 'us', language = 'en', n = 10}={}) => {
   return (await getRss(url)).items.slice(0, Math.max(0, n));
 };
 
-const website = async (query, {country = 'br', language = 'pt', n = 10}={}) => {
+const website = async (query, {country = 'us', language = 'en', n = 10}={}) => {
   const url = SEARCH_RSS + 'site%3A' + encodeURIComponent(query) + '&' +
   fillWebsiteParams(country.toUpperCase(), language.toLowerCase());
   return (await getRss(url)).items.slice(0, Math.max(0, n));

--- a/index.js
+++ b/index.js
@@ -9,8 +9,9 @@ const SEARCH_RSS    = 'https://news.google.com/rss/search?q=';
 
 const TOPICS = ['WORLD', 'NATION', 'BUSINESS', 'TECHNOLOGY', 'ENTERTAINMENT', 'SPORTS', 'SCIENCE', 'HEALTH'];
 
-const fillCountryLangParams = (country, language) => `hl=${country}
-  &gl=${language}&ceid=${country}%3A${language}`;
+const fillCountryLangParams = (country, language) => `hl=${country}&gl=${language}&ceid=${country}%3A${language}`;
+
+const fillWebsiteParams = (country, language) => `3ahl=${language}-${country}-&gl=${language}&ceid=${country}%3A${language}-419`;
 
 const getRss = async (url) => await parser.parseURL(url);
 
@@ -37,7 +38,14 @@ const search = async (query, {country = 'us', language = 'en', n = 10}={}) => {
   return (await getRss(url)).items.slice(0, Math.max(0, n));
 };
 
+const website = async (query, {country = 'br', language = 'pt', n = 10}={}) => {
+  const url = SEARCH_RSS + 'site%3A' + encodeURIComponent(query) + '&' +
+  fillWebsiteParams(country.toUpperCase(), language.toLowerCase());
+  return (await getRss(url)).items.slice(0, Math.max(0, n));
+};
+
 exports.headlines = headlines;
 exports.topic = topic;
 exports.geo = geo;
 exports.search = search;
+exports.website = website;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "Vladyslav Mokrousov",
   "license": "MIT",
   "dependencies": {
+    "gnews": "^1.0.3",
     "rss-parser": "^3.8.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,27 @@
+const news = require('gnews');
+
+const main = async () => {
+  const print = item => console.log(item.pubDate + ' | ' + item.title);
+
+  console.log('Headlines');
+  const heads = await news.headlines({n : 5});
+  heads.forEach(print);
+
+  console.log('Topics');
+  const topics = await news.topic('BUSINESS', {n : 5});
+  topics.forEach(print);
+
+  console.log('Geo');
+  const geo = await news.geo('New York', {n : 5});
+  geo.forEach(print);
+
+  console.log('Search');
+  const search = await news.search('SpaceX', {n : 5});
+  search.forEach(print);
+
+  console.log('Website');
+  const website = await news.website('https://www.starlink.com/', {n : 5});
+  website.forEach(print);
+};
+
+main();


### PR DESCRIPTION
This pull request will add an function to parse data from a specific website search

Changes to Readme with examples and added a sever.js simple example to run all options